### PR TITLE
Reassociate fallback for custom ranks for other mods' suits in `lastmoment`

### DIFF
--- a/Menthol.lua
+++ b/Menthol.lua
@@ -444,5 +444,34 @@ MINTY.lastmoment = function ()
         end
     end
 
+    -- Reassociate fallback for custom ranks for mods that load after this one
+    MINTY.build_face_rank()
+    MINTY.build_number_rank()
+
+    SMODS.Ranks["minty_face"].next = MINTY.face_rank_all_faces
+    SMODS.Ranks["minty_face"].suit_map = MINTY.face_rank_suit_map
+    SMODS.Ranks["minty_number"].next = MINTY.number_rank_all_numbers
+    SMODS.Ranks["minty_number"].suit_map = MINTY.number_rank_suitmap
+
+    for p_card, data in pairs(G.P_CARDS) do
+        if string.find(p_card, "_minty_F") then
+            data.lc_atlas = SMODS.Ranks["minty_face"].lc_atlas
+            data.hc_atlas = SMODS.Ranks["minty_face"].hc_atlas
+            data.pos = {
+                x = SMODS.Ranks["minty_face"].pos.x,
+                y = MINTY.face_rank_suitmap[data.suit]
+            }
+        end
+        if string.find(p_card, "_minty_N") then
+            data.lc_atlas = SMODS.Ranks["minty_number"].lc_atlas
+            data.hc_atlas = SMODS.Ranks["minty_number"].hc_atlas
+            data.pos = {
+                x = SMODS.Ranks["minty_number"].pos.x,
+                y = MINTY.number_rank_suitmap[data.suit]
+            }
+        end
+    end
+
+
 end
 ----

--- a/ranks/face.lua
+++ b/ranks/face.lua
@@ -1,31 +1,38 @@
-local suitmap = { --Uncomment these as the art gets arted
-    Hearts = 1,
-    Clubs = 2,
-    Diamonds = 3,
-    Spades = 4,
-    minty_3s = 5,
-    --bunc_halberds = 6,
-    --bunc_fleurons = 7,
-    --paperback_Crowns = 8,
-    --paperback_Stars = 9,
-    --six_moons = 10,
-    --six_stars = 11,
-    --Fallback = 0
-}
+function MINTY.build_face_rank()
+    local suitmap = { --Uncomment these as the art gets arted
+        Hearts = 1,
+        Clubs = 2,
+        Diamonds = 3,
+        Spades = 4,
+        minty_3s = 5,
+        --bunc_halberds = 6,
+        --bunc_fleurons = 7,
+        --paperback_Crowns = 8,
+        --paperback_Stars = 9,
+        --six_moons = 10,
+        --six_stars = 11,
+        --Fallback = 0
+    }
 
-for k,v in pairs(SMODS.Suits) do
-    if not suitmap[k] and not v.minty_facerank then
-        suitmap[k] = 0
+    for k,v in pairs(SMODS.Suits) do
+        if not suitmap[k] and not v.minty_facerank then
+            suitmap[k] = 0
+        end
     end
+
+    local all_faces = { }
+
+    for k,v in pairs(SMODS.Ranks) do
+        if v.face then
+            table.insert(all_faces, k)
+        end
+    end
+
+    MINTY.face_rank_all_faces = all_faces
+    MINTY.face_rank_suitmap = suitmap
 end
 
-local all_faces = { }
-
-for k,v in pairs(SMODS.Ranks) do
-    if v.face then
-        table.insert(all_faces, k)
-    end
-end
+MINTY.build_face_rank()
 
 SMODS.Rank{
     key = "face",
@@ -37,7 +44,7 @@ SMODS.Rank{
     hc_atlas = "facerank",
     shorthand = "F",
     face = true,
-    next = all_faces,
+    next = MINTY.face_rank_all_faces,
     strength_effect = { random = true },
     in_pool = function (self, args)
         if args and args.initial_deck then
@@ -48,7 +55,7 @@ SMODS.Rank{
         end
         return MINTY.find_rank("minty_face")
     end,
-    suit_map = suitmap,
+    suit_map = MINTY.face_rank_suit_map,
     loc_vars = function (self, info_queue, card)
         local suit = card.base.suit
         local key = "minty_faceholder_ex"

--- a/ranks/number.lua
+++ b/ranks/number.lua
@@ -1,34 +1,39 @@
-local suitmap = { --Uncomment these as the art gets arted
-    Hearts = 1,
-    Clubs = 2,
-    Diamonds = 3,
-    Spades = 4,
-    minty_3s = 5,
-    --bunc_halberds = 6,
-    --bunc_fleurons = 7,
-    --paperback_Crowns = 8,
-    --paperback_Stars = 9,
-    --six_moons = 10,
-    --six_stars = 11,
-    --Fallback = 0
-}
+function MINTY.build_number_rank()
+    local suitmap = { --Uncomment these as the art gets arted
+        Hearts = 1,
+        Clubs = 2,
+        Diamonds = 3,
+        Spades = 4,
+        minty_3s = 5,
+        --bunc_halberds = 6,
+        --bunc_fleurons = 7,
+        --paperback_Crowns = 8,
+        --paperback_Stars = 9,
+        --six_moons = 10,
+        --six_stars = 11,
+        --Fallback = 0
+    }
 
-if SMODS.Suits then
-    for k,v in pairs(SMODS.Suits) do
-        if not suitmap[k] and not v.minty_numberrank then
-            suitmap[k] = 0
+    if SMODS.Suits then
+        for k,v in pairs(SMODS.Suits) do
+            if not suitmap[k] and not v.minty_numberrank then
+                suitmap[k] = 0
+            end
         end
     end
-end
 
-local all_numbers = { }
+    local all_numbers = { }
 
-if SMODS.Ranks then
-    for k,v in pairs(SMODS.Ranks) do
-        if not v.face and k ~= "Ace" then
-            table.insert(all_numbers, k)
+    if SMODS.Ranks then
+        for k,v in pairs(SMODS.Ranks) do
+            if not v.face and k ~= "Ace" then
+                table.insert(all_numbers, k)
+            end
         end
     end
+
+    MINTY.number_rank_all_numbers = all_numbers
+    MINTY.number_rank_suitmap = suitmap
 end
 
 SMODS.Rank{
@@ -40,7 +45,7 @@ SMODS.Rank{
     lc_atlas = "numberrank",
     hc_atlas = "numberrank",
     shorthand = "N",
-    next = all_numbers,
+    next = MINTY.number_rank_all_numbers,
     strength_effect = { random = true },
     in_pool = function (self, args)
         if args and args.initial_deck then
@@ -51,7 +56,7 @@ SMODS.Rank{
         end
         return MINTY.find_rank("minty_number")
     end,
-    suit_map = suitmap,
+    suit_map = MINTY.number_rank_suitmap,
     loc_vars = function (self, info_queue, card)
         local suit = card.base.suit
         local key = "minty_placeholder"


### PR DESCRIPTION
Been using your fallback suitmap implementation for custom ranks in my own mod, and figured out a way to expand it such that it can catch other mods' suits regardless of priority load order.

In this PR, the code for building the `next` and `suit_map` values are put into global functions `MINTY.build_number_rank()` and `MINTY.build_face_()`, such that in `lastmoment`, `next` and `suit_map` can be rebuilt. Then, for all the relevant Minty rank cards in `G.P_CARDS` (ex. `bunc_FLEURONS_minty_F`), their `lc_atlas`, `hc_atlas`, and `pos` are updated to have the proper atlas value.

This prevents other mods' modded suits in your rank from appearing weirdly or pulling from the wrong atlas and position, due to their mods being loaded later (for instance UNIK)

If any of this is useful, then I hope it helps. This mod has been pretty helpful in terms of reference for building my own mod, so cheers.
